### PR TITLE
Fixing tooltip JS error

### DIFF
--- a/vendor/assets/javascripts/summernote/summernote.js
+++ b/vendor/assets/javascripts/summernote/summernote.js
@@ -6413,7 +6413,7 @@
         trigger: 'hover',
         placement: sPlacement || 'top'
       }).on('click', function () {
-        $(this).tooltip('hide');
+        $(this).tooltip('option', 'hide');
       });
     };
 


### PR DESCRIPTION
At the moment if you use the fullscreen button, it renders a JS error. This stops that error from happening, as outlined here: https://github.com/summernote/summernote/issues/542