### PR TITLE
Do not use Sprockets::Rails if is not defined

### DIFF
--- a/lib/summernote-rails/engine.rb
+++ b/lib/summernote-rails/engine.rb
@@ -3,12 +3,15 @@ module SummernoteRails
     class Engine < ::Rails::Engine
       initializer 'summernote-rails.assets.precompile' do |app|
         app.config.assets.paths << root.join('vendor', 'assets', 'fonts')
-        # fix for: https://github.com/twbs/bootstrap-sass/issues/960
-        # regex no longer supported by assets.precompile
-        # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
-        # and automatically precompiles the referenced assets.
-        unless Sprockets::Rails::VERSION.starts_with?('3')
-          app.config.assets.precompile << /\.(?:eot|woff|ttf)$/
+        
+        if defined? Sprockets::Rails
+          # fix for: https://github.com/twbs/bootstrap-sass/issues/960
+          # regex no longer supported by assets.precompile
+          # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
+          # and automatically precompiles the referenced assets.
+          unless Sprockets::Rails::VERSION.starts_with?('3')
+            app.config.assets.precompile << /\.(?:eot|woff|ttf)$/
+          end
         end
       end
     end

--- a/lib/summernote-rails/engine.rb
+++ b/lib/summernote-rails/engine.rb
@@ -3,16 +3,20 @@ module SummernoteRails
     class Engine < ::Rails::Engine
       initializer 'summernote-rails.assets.precompile' do |app|
         app.config.assets.paths << root.join('vendor', 'assets', 'fonts')
-        
-        if defined? Sprockets::Rails
-          # fix for: https://github.com/twbs/bootstrap-sass/issues/960
-          # regex no longer supported by assets.precompile
-          # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
-          # and automatically precompiles the referenced assets.
-          unless Sprockets::Rails::VERSION.starts_with?('3')
-            app.config.assets.precompile << /\.(?:eot|woff|ttf)$/
-          end
+
+        # fix for: https://github.com/twbs/bootstrap-sass/issues/960
+        # regex no longer supported by assets.precompile
+        # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
+        # and automatically precompiles the referenced assets.
+        if old_sprocket?
+          app.config.assets.precompile << /\.(?:eot|woff|ttf)$/
         end
+      end
+
+      private
+
+      def old_sprocket?
+        defined?(Sprockets::Rails) && !Sprockets::Rails::VERSION.starts_with?('3')
       end
     end
   end


### PR DESCRIPTION
Rails 3.2 do not have `Sprockets::Rails`.

---

An other alternative is #62