### PR TITLE
Use Sprockets::VERSION insted of Sprockets::Rails::VERSION

### DIFF
--- a/lib/summernote-rails/engine.rb
+++ b/lib/summernote-rails/engine.rb
@@ -7,7 +7,7 @@ module SummernoteRails
         # regex no longer supported by assets.precompile
         # sprockets-rails 3 tracks down the calls to `font_path` and `image_path`
         # and automatically precompiles the referenced assets.
-        unless Sprockets::Rails::VERSION.starts_with?('3')
+        unless Sprockets::VERSION.starts_with?('3')
           app.config.assets.precompile << /\.(?:eot|woff|ttf)$/
         end
       end


### PR DESCRIPTION
Because rails 3.2 don't have Sprockets::Rails

---

Alternative to #63